### PR TITLE
Add two explicit type arguments to make it compatible with SIP-56.

### DIFF
--- a/core/shared/src/main/scala/org/hungerford/generic/schema/product/field/FieldInjector.scala
+++ b/core/shared/src/main/scala/org/hungerford/generic/schema/product/field/FieldInjector.scala
@@ -20,7 +20,7 @@ object FieldInjector {
             type F = f
             inline fieldValues match {
                 case fvs : (F *: vts ) =>
-                    val thisRes = injector.inject( fds.head, fvs.head, into )
+                    val thisRes = injector.inject( fds.head[ Field[ t, f, n, s ] *: fs ], fvs.head[ F *: vts ], into )
                     inject( fds.tail, fvs.tail, thisRes )
                 
             }


### PR DESCRIPTION
The new match types of SIP-56 feature a stricter check to prevent some run-time unsoundness. This affects the line that is changed here. For example, for the second `.head` call, the type argument was previously inferred to `RV & (F *: vts)`. The previous check that was too relaxed let it through, although `RV` is not fully defined. We still obtain valid code by passing the new explicit type arguments instead.